### PR TITLE
adds decrease and increase buttons to the camera editor Rotation, Zoom, and FoV

### DIFF
--- a/Brio/UI/Controls/Editors/CameraEditor.cs
+++ b/Brio/UI/Controls/Editors/CameraEditor.cs
@@ -34,19 +34,19 @@ internal static class CameraEditor
                     const string rotationText = "Rotation";
                     float rotation = camera->Rotation;
                     ImGui.SetNextItemWidth(width);
-                    if(ImGui.SliderAngle(rotationText, ref rotation, -180, 180, "%.2f"))
+                    if(ImBrio.SliderAngle(rotationText, ref rotation, -180, 180, "%.2f"))
                         camera->Rotation = rotation;
 
                     const string zoomText = "Zoom";
                     float zoom = camera->Camera.Distance;
                     ImGui.SetNextItemWidth(width);
-                    if(ImGui.SliderFloat(zoomText, ref zoom, camera->Camera.MaxDistance, camera->Camera.MinDistance, "%.2f", ImGuiSliderFlags.AlwaysClamp))
+                    if(ImBrio.SliderFloat(zoomText, ref zoom, camera->Camera.MaxDistance, camera->Camera.MinDistance, "%.2f", ImGuiSliderFlags.AlwaysClamp))
                         camera->Camera.Distance = zoom;
 
                     const string fovText = "FoV";
                     float fov = camera->FoV;
                     ImGui.SetNextItemWidth(width);
-                    if(ImGui.SliderAngle(fovText, ref fov, -44, 120, "%.2f", ImGuiSliderFlags.AlwaysClamp))
+                    if(ImBrio.SliderAngle(fovText, ref fov, -44, 120, "%.2f", ImGuiSliderFlags.AlwaysClamp))
                         camera->FoV = fov;
 
                     const string panText = "Pan";

--- a/Brio/UI/Controls/Stateless/ImBrio.Slider.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.Slider.cs
@@ -1,0 +1,67 @@
+﻿using Brio.Config;
+using Brio.Core;
+using ImGuiNET;
+using System;
+
+namespace Brio.UI.Controls.Stateless;
+internal static partial class ImBrio
+{
+    public static bool SliderFloat(string label, ref float value, float min, float max, string format = "%.2f", ImGuiSliderFlags flags = ImGuiSliderFlags.None, float step = 1.0f)
+    {
+        return SliderBase(label, ref value, min, max, format, flags, step, false);
+    }
+
+    public static bool SliderAngle(string label, ref float value, float min, float max, string format = "%.2f", ImGuiSliderFlags flags = ImGuiSliderFlags.None, float step = 1.0f)
+    {
+        return SliderBase(label, ref value, min, max, format, flags, step, true);
+    }
+
+    private static bool SliderBase(string label, ref float value, float min, float max, string format, ImGuiSliderFlags flags, float step, bool isAngle = false)
+    {
+        bool changed = false;
+
+        if(max < min)
+            step = -step;
+
+        bool smallIncrement = ImGui.IsKeyDown(ConfigurationService.Instance.Configuration.Interface.IncrementSmall);
+        if(smallIncrement)
+            step /= 10;
+
+        bool largeIncrement = ImGui.IsKeyDown(ConfigurationService.Instance.Configuration.Interface.IncrementLarge);
+        if(largeIncrement)
+            step *= 10;
+
+        float buttonWidth = ImGui.GetCursorPosX();
+        if(ImGui.ArrowButton($"##{label}_decrease", ImGuiDir.Left))
+        {
+            value -= isAngle ? step * MathHelpers.DegreesToRadians : step;
+            changed = true;
+        }
+        ImGui.SameLine();
+
+        buttonWidth = ImGui.GetCursorPosX() - buttonWidth;
+
+        ImGui.SetNextItemWidth((ImGui.GetWindowWidth() * 0.65f) - (buttonWidth * 2) - ImGui.GetStyle().CellPadding.X);
+
+        if(isAngle)
+        {
+            changed |= ImGui.SliderAngle($"##{label}_slider", ref value, min, max, format, flags);
+        }
+        else
+        {
+            changed |= ImGui.SliderFloat($"##{label}_slider", ref value, min, max, format, flags);
+        }
+
+        ImGui.SameLine();
+        if(ImGui.ArrowButton($"##{label}_increase", ImGuiDir.Right))
+        {
+            value += isAngle ? step * MathHelpers.DegreesToRadians : step;
+            changed = true;
+        }
+
+        ImGui.SameLine();
+        ImGui.Text(label);
+
+        return changed;
+    }
+}


### PR DESCRIPTION
This change adds decrease and increase buttons to the camera editor rotation, zoom, and FoV sliders.
The buttons also listen for the increment Small and Large modifiers (these will need to be updated if #23 is merged)

Unsure if this is the best approach, but adding a ImBrio.Slider method seems to be pretty clean.

![image](https://github.com/AsgardXIV/Brio/assets/379714/66c6e802-dc1c-401f-9cfa-52cd5cf0a1ac)
