### PR TITLE
Hide overlay toolbar while advanced posing option

### DIFF
--- a/Brio/Config/PosingConfiguration.cs
+++ b/Brio/Config/PosingConfiguration.cs
@@ -17,6 +17,7 @@ internal class PosingConfiguration
     public uint SkeletonLineInactiveColor { get; set; } = 0x55555555;
     public bool ShowSkeletonLines { get; set; } = true;
     public bool HideGizmoWhenAdvancedPosingOpen { get; set; } = false;
+    public bool HideToolbarWhenAdvandedPosingOpen { get; set; } = false;
     public bool HideSkeletonWhenGizmoActive { get; set; } = false;
     public ImGuiKey DisableGizmoHotkey { get; set; } = ImGuiKey.LeftShift;
     public ImGuiKey DisableSkeletonHotkey { get; set; } = ImGuiKey.LeftCtrl;

--- a/Brio/UI/Windows/SettingsWindow.cs
+++ b/Brio/UI/Windows/SettingsWindow.cs
@@ -329,6 +329,13 @@ internal class SettingsWindow : Window
                 _configurationService.ApplyChange();
             }
 
+            bool hideToolbarWhenAdvancedPosingOpen = _configurationService.Configuration.Posing.HideToolbarWhenAdvandedPosingOpen;
+            if(ImGui.Checkbox("Hide Toolbar while Advanced Posing", ref hideToolbarWhenAdvancedPosingOpen))
+            {
+                _configurationService.Configuration.Posing.HideToolbarWhenAdvandedPosingOpen = hideToolbarWhenAdvancedPosingOpen;
+                _configurationService.ApplyChange();
+            }
+
             bool showSkeletonLines = _configurationService.Configuration.Posing.ShowSkeletonLines;
             if(ImGui.Checkbox("Show Skeleton Lines", ref showSkeletonLines))
             {

--- a/Brio/UI/Windows/Specialized/PosingOverlayToolbarWindow.cs
+++ b/Brio/UI/Windows/Specialized/PosingOverlayToolbarWindow.cs
@@ -1,4 +1,5 @@
 ﻿using Brio.Capabilities.Posing;
+using Brio.Config;
 using Brio.Entities;
 using Brio.Game.Posing;
 using Brio.UI.Controls.Core;
@@ -20,6 +21,7 @@ internal class PosingOverlayToolbarWindow : Window
     private readonly EntityManager _entityManager;
     private readonly PosingTransformWindow _overlayTransformWindow;
     private readonly PosingService _posingService;
+    private readonly ConfigurationService _configurationService;
 
     private readonly BoneSearchControl _boneSearchControl = new();
 
@@ -27,7 +29,7 @@ internal class PosingOverlayToolbarWindow : Window
 
     private const string _boneFilterPopupName = "bone_filter_popup";
 
-    public PosingOverlayToolbarWindow(PosingOverlayWindow overlayWindow, EntityManager entityManager, PosingTransformWindow overlayTransformWindow, PosingService posingService) : base($"Brio - Overlay###brio_posing_overlay_toolbar_window", ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoCollapse)
+    public PosingOverlayToolbarWindow(PosingOverlayWindow overlayWindow, EntityManager entityManager, PosingTransformWindow overlayTransformWindow, PosingService posingService, ConfigurationService configurationService) : base($"Brio - Overlay###brio_posing_overlay_toolbar_window", ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoCollapse)
     {
         Namespace = "brio_posing_overlay_toolbar_namespace";
 
@@ -36,12 +38,19 @@ internal class PosingOverlayToolbarWindow : Window
         _entityManager = entityManager;
         _overlayTransformWindow = overlayTransformWindow;
         _posingService = posingService;
+        _configurationService = configurationService;
         ShowCloseButton = false;
     }
 
     public override void PreOpenCheck()
     {
         IsOpen = _overlayWindow.IsOpen;
+
+        if(UIManager.IsPosingGraphicalWindowOpen && _configurationService.Configuration.Posing.HideToolbarWhenAdvandedPosingOpen)
+        {
+            IsOpen = false;
+        }
+
         base.PreOpenCheck();
     }
 


### PR DESCRIPTION
A small change to add an option to hide the overlay toolbar while the advanced pose window is open, as the advanced posing window contains most of the same options in its own toolbar.

![image](https://github.com/AsgardXIV/Brio/assets/379714/7cf30957-1ebc-48c2-9aa9-490a6f26251c)
